### PR TITLE
Serial output: Fixed issue with trailing zeroes

### DIFF
--- a/espreloj.ino
+++ b/espreloj.ino
@@ -45,9 +45,7 @@ void setup(){
 void loop() {
   timeClient.update();
 
-  
-  Serial.print(timeClient.getHours());
-  Serial.println(timeClient.getMinutes());
+  Serial.println(timeClient.getHours() * 100 + timeClient.getMinutes());
 
   delay(1000);
 }


### PR DESCRIPTION
With times like 23:05, the previous code would send "235", instead of 2305